### PR TITLE
Melhoria de performance ao retornar marcas

### DIFF
--- a/src/main/java/com/tcc5/car_price_compare/domain/vehicle/converters/BrandToBrandDTOConverter.java
+++ b/src/main/java/com/tcc5/car_price_compare/domain/vehicle/converters/BrandToBrandDTOConverter.java
@@ -10,15 +10,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class BrandToBrandDTOConverter implements Converter<Brand, BrandDTO> {
 
-    private final BrandRepository brandRepository;
-
-    public BrandToBrandDTOConverter(BrandRepository brandRepository) {
-        this.brandRepository = brandRepository;
-    }
-
     @Override
     public BrandDTO convert(Brand source) {
-        return this.brandRepository.findBrandDTOById(source.getId())
-                .orElseThrow(() -> new BrandNotFoundException(source.getId()));
+        return new BrandDTO(
+                source.getId(),
+                source.getName(),
+                source.getUrlPathName(),
+                source.getImageUrl(),
+                source.getVehicleType()
+        );
     }
 }

--- a/src/main/java/com/tcc5/car_price_compare/domain/vehicle/converters/BrandToBrandDTOConverter.java
+++ b/src/main/java/com/tcc5/car_price_compare/domain/vehicle/converters/BrandToBrandDTOConverter.java
@@ -2,8 +2,6 @@ package com.tcc5.car_price_compare.domain.vehicle.converters;
 
 import com.tcc5.car_price_compare.domain.vehicle.Brand;
 import com.tcc5.car_price_compare.domain.vehicle.dto.BrandDTO;
-import com.tcc5.car_price_compare.domain.vehicle.exceptions.BrandNotFoundException;
-import com.tcc5.car_price_compare.repositories.vehicle.BrandRepository;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
## Descrição
Esse PR ajusta a classe BrandToBrandDTOConverter para melhorar performance ao usar o endpoint de marcas de veículos. Estava sendo gerada uma query pra cada marca na conversão para DTO, agora gera apenas uma.

## Tipo de alteração

- [ ] Correção de bug;
- [x] Novo recurso;
- [ ] Refatoração de código;
- [x] Atualização de documentação.

## Lista de verificação

- [x] Segui os padrões de codificação do projeto;
- [x] Atualizei a documentação quando necessário;
- [x] Adicionei testes que comprovam que minhas alterações funcionam;
- [x] Todos os testes novos e existentes passaram.

## Capturas de tela (opcional)

![image](https://github.com/user-attachments/assets/a12d68c6-7eec-4109-86cd-4db755e8d965)


## Notas adicionais (opcional)
