### PR TITLE
Bug: erro 500 ao retornar veículo cuja marca tem categoria nula

### DIFF
--- a/src/main/java/com/tcc5/car_price_compare/services/ConversionService.java
+++ b/src/main/java/com/tcc5/car_price_compare/services/ConversionService.java
@@ -177,6 +177,7 @@ public class ConversionService {
         Year year = vehicle.getYear();
         Model model = year.getModel();
         Brand brand = model.getBrand();
+        String category = model.getCategory() == null ? "" : model.getCategory().getPortugueseTranslation();
         VehicleType vehicleType = brand.getVehicleType();
         List<FipePrice> fipePrices = vehicle.getFipePrices();
         this.sortPrices(fipePrices);
@@ -190,7 +191,7 @@ public class ConversionService {
                                       brand.getImageUrl(),
                                       year.getName(),
                                       vehicleType.name(),
-                                      model.getCategory().getPortugueseTranslation(),
+                                      category,
                                       fipePrices);
     }
 


### PR DESCRIPTION
## Descrição
Esse PR corrige um bug que fazia o endpoint `/vehicle/{id}` retornar erro 500 quando a marca associada ao veículo tinha categoria nula

## Tipo de alteração

- [ ] Correção de bug;
- [x] Novo recurso;
- [ ] Refatoração de código;
- [x] Atualização de documentação.

## Lista de verificação

- [x] Segui os padrões de codificação do projeto;
- [x] Atualizei a documentação quando necessário;
- [x] Adicionei testes que comprovam que minhas alterações funcionam;
- [x] Todos os testes novos e existentes passaram.

## Capturas de tela (opcional)

## Notas adicionais (opcional)
